### PR TITLE
fix ByteArrayToBigInt to always produce positive big int (in line with sigma)

### DIFF
--- a/sigma-impl/src/main/scala/special/sigma/SigmaDslOverArrays.scala
+++ b/sigma-impl/src/main/scala/special/sigma/SigmaDslOverArrays.scala
@@ -171,7 +171,7 @@ class TestSigmaDslBuilder extends SigmaDslBuilder {
   def PubKey(base64String: String): SigmaProp = ???
 
   @NeverInline
-  def byteArrayToBigInt(bytes: Col[Byte]): BigInteger = new BigInteger(bytes.arr)
+  def byteArrayToBigInt(bytes: Col[Byte]): BigInteger = new BigInteger(1, bytes.arr)
 
   @NeverInline
   def longToByteArray(l: Long): Col[Byte] = Cols.fromArray(Longs.toByteArray(l))

--- a/sigma-impl/src/test/scala/special/sigma/BasicOpsTests.scala
+++ b/sigma-impl/src/test/scala/special/sigma/BasicOpsTests.scala
@@ -14,6 +14,10 @@ class BasicOpsTests extends FunSuite with ContractsTestkit with Matchers {
     SigmaDsl.atLeast(3, props).isValid shouldBe false
   }
 
+  test("ByteArrayToBigInt should always produce a positive big int") {
+    SigmaDsl.byteArrayToBigInt(collection[Byte](-1)).signum shouldBe 1
+  }
+
   def test(f: Context => Boolean, ctx: Context, expected: Boolean) = {
     val contr = NoEnvContract(f)
     val res = contr.canOpen(ctx)


### PR DESCRIPTION
see [src](http://github.com/ScorexFoundation/sigmastate-interpreter/blob/515298a6988cac113796299c192bb5d25b9b4899/src/main/scala/sigmastate/trees.scala#L412)