### PR TITLE
Check that value produced by byteArrayToBigInt does not exceed dlog group order

### DIFF
--- a/sigma-impl/src/test/scala/special/sigma/BasicOpsTests.scala
+++ b/sigma-impl/src/test/scala/special/sigma/BasicOpsTests.scala
@@ -18,6 +18,11 @@ class BasicOpsTests extends FunSuite with ContractsTestkit with Matchers {
     SigmaDsl.byteArrayToBigInt(collection[Byte](-1)).signum shouldBe 1
   }
 
+  test("ByteArrayToBigInt should always produce big int less than dlog group order") {
+    an [RuntimeException] should be thrownBy
+      SigmaDsl.byteArrayToBigInt(Cols.fromArray(Array.fill[Byte](500)(1)))
+  }
+
   def test(f: Context => Boolean, ctx: Context, expected: Boolean) = {
     val contr = NoEnvContract(f)
     val res = contr.canOpen(ctx)

--- a/sigma-impl/src/test/scala/special/sigma/BasicOpsTests.scala
+++ b/sigma-impl/src/test/scala/special/sigma/BasicOpsTests.scala
@@ -1,6 +1,9 @@
 package special.sigma
 
-import org.scalatest.{Matchers, FunSuite}
+import java.math.BigInteger
+
+import org.bouncycastle.crypto.ec.CustomNamedCurves
+import org.scalatest.{FunSuite, Matchers}
 
 class BasicOpsTests extends FunSuite with ContractsTestkit with Matchers {
   test("atLeast") {
@@ -19,6 +22,19 @@ class BasicOpsTests extends FunSuite with ContractsTestkit with Matchers {
   }
 
   test("ByteArrayToBigInt should always produce big int less than dlog group order") {
+    val groupOrder = CustomNamedCurves.getByName("curve25519").getN
+
+    SigmaDsl.byteArrayToBigInt(
+      Cols.fromArray(groupOrder.subtract(BigInteger.ONE).toByteArray)
+    ).compareTo(BigInteger.ONE) shouldBe 1
+
+    SigmaDsl.byteArrayToBigInt(
+      Cols.fromArray(groupOrder.toByteArray)
+    ).compareTo(BigInteger.ONE) shouldBe 1
+
+    an [RuntimeException] should be thrownBy
+      SigmaDsl.byteArrayToBigInt(Cols.fromArray(groupOrder.add(BigInteger.ONE).toByteArray))
+
     an [RuntimeException] should be thrownBy
       SigmaDsl.byteArrayToBigInt(Cols.fromArray(Array.fill[Byte](500)(1)))
   }


### PR DESCRIPTION
Ref https://github.com/ScorexFoundation/sigmastate-interpreter/issues/311